### PR TITLE
Update steg.ai informationalUrl

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -105,7 +105,7 @@
             "description": "Steg.AI invisible watermarking",
             "dateEntered": "2024-05-20T10:50:00.000Z",
             "contact": "info@steg.ai",
-            "informationalUrl": "https://steg.ai/paper/"
+            "informationalUrl": "https://openaccess.thecvf.com/content_CVPR_2019/papers/Wengrowski_Light_Field_Messaging_With_Deep_Photographic_Steganography_CVPR_2019_paper.pdf"
         }
     },
     {


### PR DESCRIPTION
Updating steg.ai `informationalUrl` field to address https://github.com/c2pa-org/softbinding-algorithm-list/issues/17 .
Note the new `informationalUrl` points to an online pdf and not an html page, hopefully this is not an issue.