### PR TITLE
Register VideoSeal, PixelSeal & AudioSeal soft binding algorithms — AIWatermark.com

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -414,8 +414,23 @@
         }
     },
     {
-        "identifier": 29,
-<<<<<<< add-aiwatermark-videoseal
+       "identifier": 29,
+       "alg": "com.writerslogic.zwc-watermark.1",
+        "type": "watermark",
+        "encodedMediaTypes": [
+            "text/plain",
+            "text/markdown",
+            "text/html"
+        ],
+        "entryMetadata": {
+            "description": "WritersLogic CPOP zero-width character (ZWC) watermark for text content. Embeds a truncated HMAC-SHA256 tag as zero-width Unicode characters (U+200B, U+200C, U+200D, U+FEFF) at deterministic word-boundary positions selected via HMAC-seeded Fisher-Yates shuffle. The tag binds the document content hash and Merkle Mountain Range root to the authorship evidence chain, enabling blind extraction without access to the original. Robust against copy-paste and re-encoding; invalidated by content modification (by design, as content changes require re-attestation). Part of the CPOP proof-of-process authorship attestation system implementing draft-condrey-cpop-protocol",
+            "dateEntered": "2026-03-18T20:00:00.000Z",
+            "contact": "david@writerslogic.com",
+            "informationalUrl": "https://writersproof.com/cpop/zwc-watermark"
+        }
+    },
+    {
+        "identifier": 30,
         "alg": "com.aiwatermark.videoseal.1",
         "type": "watermark",
         "decodedMediaTypes": [
@@ -436,7 +451,7 @@
         ]
     },
     {
-        "identifier": 30,
+        "identifier": 31,
         "alg": "com.aiwatermark.pixelseal.1",
         "type": "watermark",
         "decodedMediaTypes": [
@@ -458,7 +473,7 @@
         ]
     },
     {
-        "identifier": 31,
+        "identifier": 32,
         "alg": "com.aiwatermark.audioseal.1",
         "type": "watermark",
         "decodedMediaTypes": [
@@ -479,20 +494,5 @@
         "softBindingResolutionApis": [
             "https://aiwatermark.com/api/v1"
         ]
-=======
-        "alg": "com.writerslogic.zwc-watermark.1",
-        "type": "watermark",
-        "encodedMediaTypes": [
-            "text/plain",
-            "text/markdown",
-            "text/html"
-        ],
-        "entryMetadata": {
-            "description": "WritersLogic CPOP zero-width character (ZWC) watermark for text content. Embeds a truncated HMAC-SHA256 tag as zero-width Unicode characters (U+200B, U+200C, U+200D, U+FEFF) at deterministic word-boundary positions selected via HMAC-seeded Fisher-Yates shuffle. The tag binds the document content hash and Merkle Mountain Range root to the authorship evidence chain, enabling blind extraction without access to the original. Robust against copy-paste and re-encoding; invalidated by content modification (by design, as content changes require re-attestation). Part of the CPOP proof-of-process authorship attestation system implementing draft-condrey-cpop-protocol",
-            "dateEntered": "2026-03-18T20:00:00.000Z",
-            "contact": "david@writerslogic.com",
-            "informationalUrl": "https://writersproof.com/cpop/zwc-watermark"
-        }
->>>>>>> main
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -423,7 +423,7 @@
             "video/webm"
         ],
         "entryMetadata": {
-            "description": "Neural video watermarking using Meta FAIR's VideoSeal model, providing perceptually invisible soft-binding watermarks in video content. Supports MP4/WebM. Integrates with C2PA manifest resolution via the AIWatermark Soft Binding Resolution API.",
+            "description": "Neural video watermarking using Meta FAIR's VideoSeal model, providing perceptually invisible soft-binding watermarks in video content. Supports MP4/WebM. Integrates with C2PA manifest resolution via the AIWatermark Soft Binding Resolution API",
             "dateEntered": "2026-03-08T00:00:00.000Z",
             "contact": "jonathan@aiwatermark.com",
             "informationalUrl": "https://aiwatermark.com/algorithms/videoseal-v1"

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -397,7 +397,7 @@
             "informationalUrl": "https://en.markany.com/contentssecurity"
         }
     },
-    {    
+    {
         "identifier": 28,
         "alg": "com.verimatrix.watermark.1",
         "type": "watermark",
@@ -410,5 +410,26 @@
             "contact": "c2pa@verimatrix.com",
             "informationalUrl": "https://www.verimatrix.com/c2pa/watermarking/"
         }
+    },
+    {
+        "identifier": 29,
+        "alg": "com.aiwatermark.videoseal.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "video"
+        ],
+        "encodedMediaTypes": [
+            "video/mp4",
+            "video/webm"
+        ],
+        "entryMetadata": {
+            "description": "Neural video watermarking using Meta FAIR's VideoSeal model, providing perceptually invisible soft-binding watermarks in video content. Supports MP4/WebM. Integrates with C2PA manifest resolution via the AIWatermark Soft Binding Resolution API.",
+            "dateEntered": "2026-03-08T00:00:00.000Z",
+            "contact": "jonathan@aiwatermark.com",
+            "informationalUrl": "https://aiwatermark.com/algorithms/videoseal-v1"
+        },
+        "softBindingResolutionApis": [
+            "https://aiwatermark.com/api/v1/resolve"
+        ]
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -429,7 +429,7 @@
             "informationalUrl": "https://aiwatermark.com/algorithms/videoseal-v1"
         },
         "softBindingResolutionApis": [
-            "https://aiwatermark.com/api/v1/resolve"
+            "https://aiwatermark.com/api/v1"
         ]
     },
     {
@@ -451,7 +451,7 @@
             "informationalUrl": "https://aiwatermark.com/algorithms/pixelseal-v1"
         },
         "softBindingResolutionApis": [
-            "https://aiwatermark.com/api/v1/resolve"
+            "https://aiwatermark.com/api/v1"
         ]
     },
     {
@@ -474,7 +474,7 @@
             "informationalUrl": "https://aiwatermark.com/algorithms/audioseal-v1"
         },
         "softBindingResolutionApis": [
-            "https://aiwatermark.com/api/v1/resolve"
+            "https://aiwatermark.com/api/v1"
         ]
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -468,7 +468,7 @@
             "audio/mp4"
         ],
         "entryMetadata": {
-            "description": "Neural audio watermarking using Meta FAIR's AudioSeal model, providing imperceptible soft-binding watermarks in audio content. Supports localized detection of watermarks within audio segments. Integrates with C2PA manifest resolution via the AIWatermark Soft Binding Resolution API.",
+            "description": "Neural audio watermarking using Meta FAIR's AudioSeal model, providing imperceptible soft-binding watermarks in audio content. Supports localized detection of watermarks within audio segments. Integrates with C2PA manifest resolution via the AIWatermark Soft Binding Resolution API",
             "dateEntered": "2026-03-08T00:00:00.000Z",
             "contact": "jonathan@aiwatermark.com",
             "informationalUrl": "https://aiwatermark.com/algorithms/audioseal-v1"

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -445,7 +445,7 @@
             "image/webp"
         ],
         "entryMetadata": {
-            "description": "Neural image watermarking using Meta FAIR's PixelSeal model, providing perceptually invisible soft-binding watermarks in image content. Embeds a 256-bit payload robust to common image transformations. Integrates with C2PA manifest resolution via the AIWatermark Soft Binding Resolution API.",
+            "description": "Neural image watermarking using Meta FAIR's PixelSeal model, providing perceptually invisible soft-binding watermarks in image content. Embeds a 256-bit payload robust to common image transformations. Integrates with C2PA manifest resolution via the AIWatermark Soft Binding Resolution API",
             "dateEntered": "2026-03-08T00:00:00.000Z",
             "contact": "jonathan@aiwatermark.com",
             "informationalUrl": "https://aiwatermark.com/algorithms/pixelseal-v1"

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -431,5 +431,50 @@
         "softBindingResolutionApis": [
             "https://aiwatermark.com/api/v1/resolve"
         ]
+    },
+    {
+        "identifier": 30,
+        "alg": "com.aiwatermark.pixelseal.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "image"
+        ],
+        "encodedMediaTypes": [
+            "image/png",
+            "image/jpeg",
+            "image/webp"
+        ],
+        "entryMetadata": {
+            "description": "Neural image watermarking using Meta FAIR's PixelSeal model, providing perceptually invisible soft-binding watermarks in image content. Embeds a 256-bit payload robust to common image transformations. Integrates with C2PA manifest resolution via the AIWatermark Soft Binding Resolution API.",
+            "dateEntered": "2026-03-08T00:00:00.000Z",
+            "contact": "jonathan@aiwatermark.com",
+            "informationalUrl": "https://aiwatermark.com/algorithms/pixelseal-v1"
+        },
+        "softBindingResolutionApis": [
+            "https://aiwatermark.com/api/v1/resolve"
+        ]
+    },
+    {
+        "identifier": 31,
+        "alg": "com.aiwatermark.audioseal.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "audio"
+        ],
+        "encodedMediaTypes": [
+            "audio/mpeg",
+            "audio/wav",
+            "audio/flac",
+            "audio/mp4"
+        ],
+        "entryMetadata": {
+            "description": "Neural audio watermarking using Meta FAIR's AudioSeal model, providing imperceptible soft-binding watermarks in audio content. Supports localized detection of watermarks within audio segments. Integrates with C2PA manifest resolution via the AIWatermark Soft Binding Resolution API.",
+            "dateEntered": "2026-03-08T00:00:00.000Z",
+            "contact": "jonathan@aiwatermark.com",
+            "informationalUrl": "https://aiwatermark.com/algorithms/audioseal-v1"
+        },
+        "softBindingResolutionApis": [
+            "https://aiwatermark.com/api/v1/resolve"
+        ]
     }
 ]


### PR DESCRIPTION
## Summary

Registers three neural watermarking algorithms from AIWatermark.com (Retiretainment LLC), each powered by Meta FAIR open-source models:

| # | Algorithm ID | Media | Model |
|---|---|---|---|
| 29 | `com.aiwatermark.videoseal.1` | video/mp4, video/webm | Meta VideoSeal |
| 30 | `com.aiwatermark.pixelseal.1` | image/png, image/jpeg, image/webp | Meta PixelSeal |
| 31 | `com.aiwatermark.audioseal.1` | audio/mpeg, audio/wav, audio/flac, audio/mp4 | Meta AudioSeal |

All three share a common Soft Binding Resolution API live at https://aiwatermark.com/api/v1/ with `/resolve`, `/algorithms`, `/health`, and `/info` endpoints.

## Algorithm details

**VideoSeal (`com.aiwatermark.videoseal.1`)**
- Perceptually invisible watermarks embedded directly into video frames
- Payload survives compression, re-encoding, and resizing
- Informational URL: https://aiwatermark.com/algorithms/videoseal-v1

**PixelSeal (`com.aiwatermark.pixelseal.1`)**
- Neural image watermarking with 256-bit payload
- Robust to common image transformations (JPEG compression, resizing, cropping)
- Informational URL: https://aiwatermark.com/algorithms/pixelseal-v1

**AudioSeal (`com.aiwatermark.audioseal.1`)**
- Imperceptible audio watermarking with localized segment detection
- Supports MP3, WAV, FLAC, and M4A
- Informational URL: https://aiwatermark.com/algorithms/audioseal-v1

**Contact:** jonathan@aiwatermark.com
**Resolution endpoint:** https://aiwatermark.com/api/v1/resolve