### PR TITLE
feat: Register WritersLogic CPOP ZWC text watermark (ID 29)

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -410,5 +410,21 @@
             "contact": "c2pa@verimatrix.com",
             "informationalUrl": "https://www.verimatrix.com/c2pa/watermarking/"
         }
+    },
+    {
+        "identifier": 29,
+        "alg": "com.writerslogic.zwc-watermark.1",
+        "type": "watermark",
+        "encodedMediaTypes": [
+            "text/plain",
+            "text/markdown",
+            "text/html"
+        ],
+        "entryMetadata": {
+            "description": "WritersLogic CPOP zero-width character (ZWC) watermark for text content. Embeds a truncated HMAC-SHA256 tag as zero-width Unicode characters (U+200B, U+200C, U+200D, U+FEFF) at deterministic word-boundary positions selected via HMAC-seeded Fisher-Yates shuffle. The tag binds the document content hash and Merkle Mountain Range root to the authorship evidence chain, enabling blind extraction without access to the original. Robust against copy-paste and re-encoding; invalidated by content modification (by design, as content changes require re-attestation). Part of the CPOP proof-of-process authorship attestation system implementing draft-condrey-cpop-protocol",
+            "dateEntered": "2026-03-18T20:00:00.000Z",
+            "contact": "david@writerslogic.com",
+            "informationalUrl": "https://writersproof.com/cpop/zwc-watermark"
+        }
     }
 ]


### PR DESCRIPTION
## Summary

Registering a zero-width character (ZWC) watermark algorithm for text content on behalf of WritersLogic.

- **Algorithm**: `com.writerslogic.zwc-watermark.1`
- **Type**: watermark
- **Media types**: `text/plain`, `text/markdown`, `text/html`
- **Identifier**: 29

## Algorithm Description

Embeds a truncated HMAC-SHA256 tag as invisible zero-width Unicode characters (U+200B, U+200C, U+200D, U+FEFF) at deterministic word-boundary positions selected via HMAC-seeded Fisher-Yates shuffle. Each ZWC encodes 2 bits; 32 ZWCs produce a 64-bit tag that binds the document content hash and Merkle Mountain Range root to the authorship evidence chain.

The watermark enables blind extraction (no original required), survives copy-paste and re-encoding, and is intentionally invalidated by content modification — content changes require re-attestation under the CPOE proof-of-process protocol.

This is the first text-only soft binding algorithm in the registry, complementing the existing image/audio/video watermarks.

## Context

Part of the CPOE (Cryptographic Proof-of-Effort) protocol implementing [draft-condrey-cpop-protocol](https://github.com/LF-Decentralized-Trust-labs/proof-of-effort). The algorithm is open-source under AGPL-3.0 at [writerslogic/cpoe](https://github.com/writerslogic/cpoe).

## Checklist

- [x] Entry follows schema (`softbinding-algorithm-list.schema.json`)
- [x] `alg` uses entity-specific namespace (`com.writerslogic.*`)
- [x] `identifier` is next sequential (29)
- [x] `contact` email provided
- [x] `informationalUrl` provided
- [x] JSON is valid