### PR TITLE
Add image and audio media types to castLabs watermark

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -169,7 +169,9 @@
         "alg": "castLabs.watermark.1",
         "type": "watermark",
         "decodedMediaTypes": [
-            "video"
+            "video",
+            "image",
+            "audio"
         ],
         "entryMetadata": {
             "description": "castLabs Single Frame Forensic Watermarking",


### PR DESCRIPTION
## Summary
- Adds `image` and `audio` to the `decodedMediaTypes` for the `castLabs.watermark.1` entry (identifier 12)
- The castLabs watermark now supports video, image, and audio media types