### PR TITLE
Add Meta Seal watermarking algorithms (PixelSeal, ChunkySeal, VideoSeal, AudioSeal, TextSeal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The soft binding assertion contains a field `alg` which uniquely identifies the 
 ## Guidelines for submitting a new entry
 
 ### Pull request
-Developers of soft binding algorithms may request these be added as new entries in the soft binding algorithm list. Developers may also request amendments to their entries. These requests are made by submitting a Pull Request (PR) that adds to, or edits, the [softbinding-algorithm-list JSON array](softbinding-algorithm-list.json) in this repository and following the [schema](softbinding-algorithm-list-schema.json).
+Developers of soft binding algorithms may request these be added as new entries in the soft binding algorithm list. Developers may also request amendments to their entries. These requests are made by submitting a Pull Request (PR) that adds to, or edits, the [softbinding-algorithm-list JSON array](softbinding-algorithm-list.json) in this repository and following the [schema](softbinding-algorithm-list.schema.json).
 
 ### Selection rules
 
@@ -16,7 +16,7 @@ The C2PA Technical Working Group will approve and merge PRs in accordance with i
 C2PA's Technical Working Group may also decide to remove malicious or non-conformant entries from the list of approved soft binding algorithms.
 
 For a PR (new entry or update) to be approved the following criteria are important:
-- The entry shall conform with the [schema](softbinding-algorithm-list-schema.json) and shall include all the mandatory fields.
+- The entry shall conform with the [schema](softbinding-algorithm-list.schema.json) and shall include all the mandatory fields.
 - The entry shall not appear to be malicious (e.g., spam) or harmful.
 - The PR shall be submitted by an individual affiliated with the company owning the submitted proprietary algorithm or a maintainer of the submitted open source algorithm or its fork.
 - The provided URLs shall successfully resolve (e.g., `softBindingResolutionApis`, `informationalUrl`).

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -508,5 +508,19 @@
             "contact": "opensource@meta.com",
             "informationalUrl": "https://github.com/facebookresearch/videoseal"
         }
+    },
+    {
+        "identifier": 34,
+        "alg": "com.meta.chunkyseal.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "image"
+        ],
+        "entryMetadata": {
+            "description": "Meta ChunkySeal high capacity image watermarking",
+            "dateEntered": "2026-04-16T09:00:00.000Z",
+            "contact": "opensource@meta.com",
+            "informationalUrl": "https://github.com/facebookresearch/videoseal"
+        }
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -494,5 +494,19 @@
         "softBindingResolutionApis": [
             "https://aiwatermark.com/api/v1"
         ]
+    },
+    {
+        "identifier": 33,
+        "alg": "com.meta.pixelseal.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "image"
+        ],
+        "entryMetadata": {
+            "description": "Meta PixelSeal invisible image watermarking",
+            "dateEntered": "2026-04-16T09:00:00.000Z",
+            "contact": "opensource@meta.com",
+            "informationalUrl": "https://github.com/facebookresearch/videoseal"
+        }
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -536,5 +536,19 @@
             "contact": "opensource@meta.com",
             "informationalUrl": "https://github.com/facebookresearch/videoseal"
         }
+    },
+    {
+        "identifier": 36,
+        "alg": "com.meta.audioseal.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "audio"
+        ],
+        "entryMetadata": {
+            "description": "Meta AudioSeal localized audio watermarking",
+            "dateEntered": "2026-04-16T09:00:00.000Z",
+            "contact": "opensource@meta.com",
+            "informationalUrl": "https://github.com/facebookresearch/audioseal"
+        }
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -550,5 +550,19 @@
             "contact": "opensource@meta.com",
             "informationalUrl": "https://github.com/facebookresearch/audioseal"
         }
+    },
+    {
+        "identifier": 37,
+        "alg": "com.meta.textseal.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "text"
+        ],
+        "entryMetadata": {
+            "description": "Meta TextSeal text watermarking",
+            "dateEntered": "2026-04-16T09:00:00.000Z",
+            "contact": "opensource@meta.com",
+            "informationalUrl": "https://github.com/facebookresearch/textseal"
+        }
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -522,5 +522,19 @@
             "contact": "opensource@meta.com",
             "informationalUrl": "https://github.com/facebookresearch/videoseal"
         }
+    },
+    {
+        "identifier": 35,
+        "alg": "com.meta.videoseal.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "video"
+        ],
+        "entryMetadata": {
+            "description": "Meta VideoSeal video watermarking",
+            "dateEntered": "2026-04-16T09:00:00.000Z",
+            "contact": "opensource@meta.com",
+            "informationalUrl": "https://github.com/facebookresearch/videoseal"
+        }
     }
 ]


### PR DESCRIPTION
Registers some of the open source watermarking algorithms from [Meta Seal](https://github.com/facebookresearch/meta-seal) suite as soft binding algorithms for C2PA:

| ID | Algorithm | Type | Media |
|----|-----------|------|-------|
| 33 | `com.meta.pixelseal.1` | watermark | image |
| 34 | `com.meta.chunkyseal.1` | watermark | image |
| 35 | `com.meta.videoseal.1` | watermark | video |
| 36 | `com.meta.audioseal.1` | watermark | audio |
| 37 | `com.meta.textseal.1` | watermark | text |

I noticed the `com.aiwatermark` related entries, which appears to be a paid service exposing these same models. If I understand things correctly, then this algorithm list is to be used as a list of potential watermark implementations that would be required to detect all potential cases of content using a C2PA Soft Binding? Which leaves me a little concerned that it could lead to many paid providers re-exposing open source models, such that ultimately the C2PA manifest can't be discovered without paying for access. It seems a little counter intuitive to define an interoperable Soft Binding API spec, yet providers can register here behind paywalls.

I have also included an additional fix in `README.md` from `softbinding-algorithm-list-schema.json` to `softbinding-algorithm-list.schema.json`.