### PR TITLE
Add VerdaAI watermarking algorithms (image, video, audio)

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -512,5 +512,64 @@
             "contact": "contact@sasha.eu",
             "informationalUrl": "https://sasha.eu/technology"
         }
+    },
+    {
+        "identifier": 34,
+        "alg": "ai.verda.watermark.image.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "image"
+        ],
+        "encodedMediaTypes": [
+            "image/png",
+            "image/jpeg",
+            "image/avif"
+        ],
+        "entryMetadata": {
+            "description": "VerdaAI invisible image watermarking",
+            "dateEntered": "2026-04-16T00:00:00.000Z",
+            "contact": "harsha@verda.ai",
+            "informationalUrl": "https://verda.ai/watermarking"
+        }
+    },
+    {
+        "identifier": 35,
+        "alg": "ai.verda.watermark.video.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "video"
+        ],
+        "encodedMediaTypes": [
+            "video/mp4",
+            "video/webm",
+            "video/quicktime"
+        ],
+        "entryMetadata": {
+            "description": "VerdaAI invisible video watermarking",
+            "dateEntered": "2026-04-16T00:00:00.000Z",
+            "contact": "harsha@verda.ai",
+            "informationalUrl": "https://verda.ai/watermarking"
+        }
+    },
+    {
+        "identifier": 36,
+        "alg": "ai.verda.watermark.audio.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "audio"
+        ],
+        "encodedMediaTypes": [
+            "audio/mpeg",
+            "audio/wav",
+            "audio/aac",
+            "audio/ogg",
+            "audio/flac"
+        ],
+        "entryMetadata": {
+            "description": "VerdaAI invisible audio watermarking",
+            "dateEntered": "2026-04-16T00:00:00.000Z",
+            "contact": "harsha@verda.ai",
+            "informationalUrl": "https://verda.ai/watermarking"
+        }
     }
 ]


### PR DESCRIPTION
## Summary

Adds three new soft binding algorithm entries for VerdaAI:

- **`ai.verda.watermark.image.1`** — Invisible image watermarking (PNG, JPEG, AVIF)
- **`ai.verda.watermark.video.1`** — Invisible video watermarking (MP4, WebM, QuickTime)
- **`ai.verda.watermark.audio.1`** — Invisible audio watermarking (MP3, WAV, AAC, OGG, FLAC)

All three algorithms embed imperceptible watermarks that enable content tracing and C2PA manifest recovery. They are robust against common media transformations including compression, resizing, transcoding, and format conversion.

**Informational URL:** https://verda.ai/watermarking
**Contact:** harsha@verda.ai