### PR TITLE
Register EAW and EFP soft binding algorithms by Evixar Inc.

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -494,5 +494,35 @@
         "softBindingResolutionApis": [
             "https://aiwatermark.com/api/v1"
         ]
+    },
+    {
+        "identifier": 33,
+        "alg": "com.evixar.eaw.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "audio",
+            "video"
+        ],
+        "entryMetadata": {
+            "description": "EAW (Evixar Audio Watermark) is an audible-range audio watermarking algorithm developed by Evixar Inc. Embeds and extracts a soft binding identifier for C2PA manifest recovery.",
+            "dateEntered": "2026-04-24T00:00:00.000Z",
+            "contact": "c2pa@evixar.com",
+            "informationalUrl": "https://www.evixar.com/en/technology/eaw/"
+        }
+    },
+    {
+        "identifier": 34,
+        "alg": "com.evixar.efp.type3.1",
+        "type": "fingerprint",
+        "decodedMediaTypes": [
+            "audio",
+            "video"
+        ],
+        "entryMetadata": {
+            "description": "EFP Type 3 (Evixar Finger Print Type 3) is an audio fingerprinting algorithm developed by Evixar Inc. Extracts a soft binding identifier from registered content via fingerprint matching for C2PA manifest recovery.",
+            "dateEntered": "2026-04-24T00:00:00.000Z",
+            "contact": "c2pa@evixar.com",
+            "informationalUrl": "https://www.evixar.com/en/technology/efp/"
+        }
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -496,7 +496,7 @@
         ]
     },
     {
-        "identifier": 33,
+        "identifier": 37,
         "alg": "com.evixar.eaw.1",
         "type": "watermark",
         "decodedMediaTypes": [

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -511,7 +511,7 @@
         }
     },
     {
-        "identifier": 34,
+        "identifier": 38,
         "alg": "com.evixar.efp.type3.1",
         "type": "fingerprint",
         "decodedMediaTypes": [


### PR DESCRIPTION
## Summary

Adds two soft binding algorithm entries for Evixar Inc. (Tokyo, Japan):

- **`com.evixar.eaw.1`** — EAW (Evixar Audio Watermark), `type: watermark`, applicable to audio and audio tracks of video.
- **`com.evixar.efp.type3.1`** — EFP Type 3 (Evixar Finger Print Type 3), `type: fingerprint`, applicable to audio and audio tracks of video.

Both are proprietary production algorithms developed in-house by Evixar Inc. Details are documented on each algorithm's informationalUrl.

**Informational URLs:**
- EAW: https://www.evixar.com/en/technology/eaw/
- EFP Type 3: https://www.evixar.com/en/technology/efp/

**Contact:** c2pa@evixar.com
