### PR TITLE
Fix JSON syntax: missing closing brace after VerdaAI audio entry

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -570,6 +570,9 @@
             "dateEntered": "2026-04-16T00:00:00.000Z",
             "contact": "harsha@verda.ai",
             "informationalUrl": "https://verda.ai/watermarking"
+        }
+    },
+    {
         "identifier": 37,
         "alg": "com.evixar.eaw.1",
         "type": "watermark",


### PR DESCRIPTION
The merge of #49 dropped the closing `}` and `},` between the VerdaAI audio watermark entry (ID 36) and the Evixar entry (ID 37), producing invalid JSON.

This adds the missing three lines to restore valid syntax.