### PR TITLE
Updated softbinding-algorithm-list to include VSRMark 

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -601,5 +601,19 @@
             "contact": "c2pa@evixar.com",
             "informationalUrl": "https://www.evixar.com/en/technology/efp/"
         }
+    },
+    {
+        "identifier": 39,
+        "alg": "com.cognitive-proof.vsrmark.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "text"
+        ],
+        "entryMetadata": {
+            "description": "VSRMark hides a structured byte payload inside visible Unicode text by appending invisible Variation Selectors after visible characters. Each hidden byte maps to one variation selector. The payload is wrapped in a block containing a magic identifier (VSR1), version number, payload length, and CRC32 checksum.",
+            "dateEntered": "2026-06-04T00:00:00.000Z",
+            "contact": "support@cognitive-proof.com",
+            "informationalUrl": "https://github.com/Cognitive-Proof/VSRMark"
+        }
     }
 ]


### PR DESCRIPTION
 Add VSRMark (com.cognitive-proof.vsrmark.1) — Unicode Variation Selector text watermark
  
  This PR adds VSRMark, a text steganography algorithm developed by Cognitive Proof (https://cognitive-proof.com/), to
  the soft binding algorithm list as identifier 39.

  Algorithm summary
  
  VSRMark hides a structured byte payload inside visible Unicode text by appending Unicode Variation Selectors
  (U+FE00–U+FE0F and U+E0100–U+E01EF) after visible characters. Each hidden byte maps to exactly one variation selector,
  making the encoded text visually identical to the original. The payload is wrapped in a self-describing block with a
  magic identifier (VSR1), version number, big-endian payload length, and CRC32 checksum for integrity verification.

  Submission checklist

  - [x] Entry conforms to softbinding-algorithm-list.schema.json
  - [x] All mandatory fields are present (identifier, alg, type, decodedMediaTypes, entryMetadata)
  - [x] identifier (39) is the next sequential value
  - [x] alg uses reverse-domain notation under the submitter's owned domain (cognitive-proof.com)
  - [x] informationalUrl is functional
  - [x] Submitter is a maintainer of the open-source algorithm

  Reference implementation

  https://github.com/Cognitive-Proof/VSRMark                                                          

  ---
