### PR TITLE
Add DeepMark entry to the C2PA soft binding algorithm list

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -601,5 +601,22 @@
             "contact": "c2pa@evixar.com",
             "informationalUrl": "https://www.evixar.com/en/technology/efp/"
         }
+    },
+    {
+        "identifier": 40,
+        "alg": "me.deepmark.audio.vigil.128",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "audio"
+        ],
+        "entryMetadata": {
+            "description": "Vigil is a 128-bit-per-second neural audio watermarking algorithm developed by DeepMark Inc. Real-time capable on both CPU and GPU. Embedding can be performed by the DeepMark ingestion API at https://ingestion-api.deepmark.me. NOTE: This deployment signs manifests with test certificates, so manifest signatures will not validate against any trust authority.",
+            "dateEntered": "2026-06-05T00:00:00Z",
+            "contact": "hello@deepmark.me",
+            "informationalUrl": "https://www.deepmark.me"
+        },
+        "softBindingResolutionApis": [
+            "https://resolution-api.deepmark.me"
+        ]
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -607,10 +607,10 @@
         "alg": "me.deepmark.audio.vigil.128",
         "type": "watermark",
         "decodedMediaTypes": [
-            "audio"
+            "audio",
         ],
         "entryMetadata": {
-            "description": "Vigil is a 128-bit-per-second neural audio watermarking algorithm developed by DeepMark Inc. Real-time capable on both CPU and GPU. Embedding can be performed by the DeepMark ingestion API at https://ingestion-api.deepmark.me. NOTE: This deployment signs manifests with test certificates, so manifest signatures will not validate against any trust authority.",
+            "description": "Vigil is a 128-bit-per-second neural audio watermarking algorithm developed by DeepMark Inc. Real-time capable on both CPU and GPU. Embedding can be performed by the demo DeepMark ingestion API at https://ingestion-api.deepmark.me. NOTE: This is a demo/playground deployment that signs manifests with test certificates, so manifest signatures will not validate against any trust authority.",
             "dateEntered": "2026-06-05T00:00:00Z",
             "contact": "hello@deepmark.me",
             "informationalUrl": "https://www.deepmark.me"

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -607,7 +607,7 @@
         "alg": "me.deepmark.audio.vigil.128",
         "type": "watermark",
         "decodedMediaTypes": [
-            "audio",
+            "audio"
         ],
         "entryMetadata": {
             "description": "Vigil is a 128-bit-per-second neural audio watermarking algorithm developed by DeepMark Inc. Real-time capable on both CPU and GPU. Embedding can be performed by the demo DeepMark ingestion API at https://ingestion-api.deepmark.me. NOTE: This is a demo/playground deployment that signs manifests with test certificates, so manifest signatures will not validate against any trust authority.",


### PR DESCRIPTION
This PR registers DeepMark's Vigil watermark with the C2PA soft binding list. 

Vigil is a 128-bit-per-second neural audio watermarking algorithm. It's identified as "me.deepmark.audio.vigil.128".

- Bindings can be resolved via our hosted resolution API at https://resolution-api.deepmark.me. 
- Watermark embedding can be exercised via the hosted ingestion playground at https://ingestion-api.deepmark.me. 
- Both services are open sourced at https://github.com/deepmark/c2pa-soft-binding-stack. The same codebase can be self-hosted to run your own ingestion and resolution nodes.

IMPORTANT NOTES: 
- The hosted playground ingestion API signs manifests with testing certificates, so signatures from it won't validate against any trust authority. It's intended as a demo, not a production signing service.
- All routes on the hosted services are unauthenticated. Do not upload sensitive or confidential audio.