### PR TITLE
Add com.writerslogic.text-fingerprint.1 (fingerprint, text)

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -629,7 +629,7 @@
             "description": "WritersLogic CPoE robust text fingerprint. Computes a 256-bit SimHash over overlapping character 4-grams of normalized text and records the hex-encoded value as a fingerprint-type soft binding for manifest recovery. Normalization applies Unicode NFC, removes zero-width and formatting characters (U+200B, U+200C, U+200D, U+FEFF, U+2060, variation selectors U+FE00-U+FE0F), lowercases, collapses whitespace, and strips punctuation, so the fingerprint is unchanged by reformatting, re-encoding, case and whitespace edits, and zero-width-character injection. Character 4-grams keep a single-word edit local, so the fingerprint stays stable even on short, one-sentence text. The document is additionally split into overlapping 512-character windows (50% overlap) that are each fingerprinted, recorded as scoped blocks (start, length) alongside the whole-document block, so an extracted excerpt or truncated copy can be matched against a window block. Two fingerprints match when their Hamming distance is at most 32 bits (12.5%), identifying the same content under light edits. Robust to edits and formatting but not to paraphrase. Part of the CPoE proof-of-effort authorship attestation system implementing draft-condrey-cpoe-protocol.",
             "dateEntered": "2026-06-22T00:00:00.000Z",
             "contact": "david@writerslogic.com",
-            "informationalUrl": "https://writersproof.com/cpoe/text-fingerprint"
+            "informationalUrl": "https://writerslogic.com/docs/text-fingerprint"
         }
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -629,7 +629,7 @@
             "description": "WritersLogic CPoE robust text fingerprint. Computes a 256-bit SimHash over overlapping character 4-grams of normalized text and records the hex-encoded value as a fingerprint-type soft binding for manifest recovery. Normalization applies Unicode NFC, removes zero-width and formatting characters (U+200B, U+200C, U+200D, U+FEFF, U+2060, variation selectors U+FE00-U+FE0F), lowercases, collapses whitespace, and strips punctuation, so the fingerprint is unchanged by reformatting, re-encoding, case and whitespace edits, and zero-width-character injection. Character 4-grams keep a single-word edit local, so the fingerprint stays stable even on short, one-sentence text. The document is additionally split into overlapping 512-character windows (50% overlap) that are each fingerprinted, recorded as scoped blocks (start, length) alongside the whole-document block, so an extracted excerpt or truncated copy can be matched against a window block. Two fingerprints match when their Hamming distance is at most 32 bits (12.5%), identifying the same content under light edits. Robust to edits and formatting but not to paraphrase. Part of the CPoE proof-of-effort authorship attestation system implementing draft-condrey-cpoe-protocol.",
             "dateEntered": "2026-06-22T00:00:00.000Z",
             "contact": "david@writerslogic.com",
-            "informationalUrl": "https://docs.writerslogic.com/soft-bindings/text-fingerprint"
+            "informationalUrl": "https://docs.writerslogic.com/soft-binding/text-fingerprint"
         }
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -621,7 +621,7 @@
         }
     },
     {
-        "identifier": 40,
+        "identifier": 41,
         "alg": "com.writerslogic.text-fingerprint.1",
         "type": "fingerprint",
         "encodedMediaTypes": [

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -615,5 +615,21 @@
             "contact": "support@cognitive-proof.com",
             "informationalUrl": "https://github.com/Cognitive-Proof/VSRMark"
         }
+    },
+    {
+        "identifier": 40,
+        "alg": "com.writerslogic.text-fingerprint.1",
+        "type": "fingerprint",
+        "encodedMediaTypes": [
+            "text/plain",
+            "text/markdown",
+            "text/html"
+        ],
+        "entryMetadata": {
+            "description": "WritersLogic CPoE robust text fingerprint. Computes a 256-bit SimHash over overlapping character 4-grams of normalized text and records the hex-encoded value as a fingerprint-type soft binding for manifest recovery. Normalization applies Unicode NFC, removes zero-width and formatting characters (U+200B, U+200C, U+200D, U+FEFF, U+2060, variation selectors U+FE00-U+FE0F), lowercases, collapses whitespace, and strips punctuation, so the fingerprint is unchanged by reformatting, re-encoding, case and whitespace edits, and zero-width-character injection. Character 4-grams keep a single-word edit local, so the fingerprint stays stable even on short, one-sentence text. The document is additionally split into overlapping 512-character windows (50% overlap) that are each fingerprinted, recorded as scoped blocks (start, length) alongside the whole-document block, so an extracted excerpt or truncated copy can be matched against a window block. Two fingerprints match when their Hamming distance is at most 32 bits (12.5%), identifying the same content under light edits. Robust to edits and formatting but not to paraphrase. Part of the CPoE proof-of-effort authorship attestation system implementing draft-condrey-cpoe-protocol.",
+            "dateEntered": "2026-06-22T00:00:00.000Z",
+            "contact": "david@writerslogic.com",
+            "informationalUrl": "https://writersproof.com/cpoe/text-fingerprint"
+        }
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -629,7 +629,7 @@
             "description": "WritersLogic CPoE robust text fingerprint. Computes a 256-bit SimHash over overlapping character 4-grams of normalized text and records the hex-encoded value as a fingerprint-type soft binding for manifest recovery. Normalization applies Unicode NFC, removes zero-width and formatting characters (U+200B, U+200C, U+200D, U+FEFF, U+2060, variation selectors U+FE00-U+FE0F), lowercases, collapses whitespace, and strips punctuation, so the fingerprint is unchanged by reformatting, re-encoding, case and whitespace edits, and zero-width-character injection. Character 4-grams keep a single-word edit local, so the fingerprint stays stable even on short, one-sentence text. The document is additionally split into overlapping 512-character windows (50% overlap) that are each fingerprinted, recorded as scoped blocks (start, length) alongside the whole-document block, so an extracted excerpt or truncated copy can be matched against a window block. Two fingerprints match when their Hamming distance is at most 32 bits (12.5%), identifying the same content under light edits. Robust to edits and formatting but not to paraphrase. Part of the CPoE proof-of-effort authorship attestation system implementing draft-condrey-cpoe-protocol.",
             "dateEntered": "2026-06-22T00:00:00.000Z",
             "contact": "david@writerslogic.com",
-            "informationalUrl": "https://writerslogic.com/docs/text-fingerprint"
+            "informationalUrl": "https://docs.writerslogic.com/soft-bindings/text-fingerprint"
         }
     }
 ]


### PR DESCRIPTION
## Add `com.writerslogic.text-fingerprint.1` (fingerprint, text)

This PR adds a new entry (identifier **40**) for a **fingerprint**-type soft
binding for text content.

### Algorithm

`com.writerslogic.text-fingerprint.1` computes a durable 256-bit fingerprint
*from* the words of a document (rather than embedding hidden markers into it):

1. **Normalize** to a single character stream: Unicode NFC; remove zero-width /
   formatting characters (U+200B, U+200C, U+200D, U+FEFF, U+2060, variation
   selectors U+FE00–U+FE0F); lowercase; collapse whitespace runs to a single
   space; strip punctuation; trim.
2. **Character 4-grams**: overlapping character 4-grams over the normalized
   string (sliding window of 4 chars, step 1; a single n-gram of the whole
   string when it is shorter than 4 chars). Character grams keep a single-word
   edit local, so the fingerprint stays stable on short text where word shingles
   moved too far.
3. **SimHash-256**: SHA-256 each 4-gram to a 256-bit vector; for each bit
   position sum +1/−1 across grams; the final bit is 1 when the column sum
   is `> 0`. Output is 32 bytes, hex-encoded.
4. **Match**: Hamming distance ≤ 32 bits (12.5%) indicates the same content
   under light edits.
5. **Windowed fingerprints**: the normalized stream is also split into
   overlapping windows of 512 characters with 50% overlap (step 256) and each
   window fingerprinted separately. The soft binding records the whole-document
   fingerprint as block 0 (empty scope) and one block per window
   (`scope: {start, length}`), so an extracted excerpt or truncated copy can be
   matched against a window block even when its whole-document fingerprint has
   drifted.

### Why a computed fingerprint (vs. an embedded ZWC watermark)

The fingerprint is derived from the visible words and recorded in the
agent-signed C2PA manifest, so it is **non-destructive** (nothing is added to
the document), **normalization-proof** (reformatting, case, whitespace, and
punctuation changes happen before hashing), **ZWC-immune** (normalization
removes zero-width characters and variation selectors, so injecting them does
not change the fingerprint), and **forge / transfer-resistant** (the value is
bound by the manifest signature and cannot be lifted onto another document
without re-signing).

**Honest limit:** robust to edits and formatting (including a single-word edit
on a one-sentence snippet, thanks to character 4-grams), not to paraphrase.

This algorithm is part of the WritersLogic CPoE proof-of-effort authorship
attestation system, alongside the existing `com.writerslogic.zwc-watermark.1`
entry (identifier 29).

### Checklist

- [x] Entry conforms to the schema and includes all mandatory fields.
- [x] File remains valid JSON (`python -m json.tool`).
- [x] Next free integer `identifier` (40) assigned; no collisions.
- [x] Submitted by an individual affiliated with WritersLogic.
- [x] `informationalUrl` provided.
- [x] Commit signed off (DCO).
