### PR TITLE
Add DeepMark entry to the C2PA soft binding algorithm list

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -625,7 +625,7 @@
         "alg": "me.deepmark.audio.vigil.128",
         "type": "watermark",
         "decodedMediaTypes": [
-            "audio",
+            "audio"
         ],
         "entryMetadata": {
             "description": "Vigil is a 128-bit-per-second neural audio watermarking algorithm developed by DeepMark Inc. Real-time capable on both CPU and GPU. Embedding can be performed by the demo DeepMark ingestion API at https://ingestion-api.deepmark.me. NOTE: This is a demo/playground deployment that signs manifests with test certificates, so manifest signatures will not validate against any trust authority.",

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -625,10 +625,10 @@
         "alg": "me.deepmark.audio.vigil.128",
         "type": "watermark",
         "decodedMediaTypes": [
-            "audio"
+            "audio",
         ],
         "entryMetadata": {
-            "description": "Vigil is a 128-bit-per-second neural audio watermarking algorithm developed by DeepMark Inc. Real-time capable on both CPU and GPU. Embedding can be performed by the DeepMark ingestion API at https://ingestion-api.deepmark.me. NOTE: This deployment signs manifests with test certificates, so manifest signatures will not validate against any trust authority.",
+            "description": "Vigil is a 128-bit-per-second neural audio watermarking algorithm developed by DeepMark Inc. Real-time capable on both CPU and GPU. Embedding can be performed by the demo DeepMark ingestion API at https://ingestion-api.deepmark.me. NOTE: This is a demo/playground deployment that signs manifests with test certificates, so manifest signatures will not validate against any trust authority.",
             "dateEntered": "2026-06-05T00:00:00Z",
             "contact": "hello@deepmark.me",
             "informationalUrl": "https://www.deepmark.me"

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -418,8 +418,8 @@
         }
     },
     {
-       "identifier": 29,
-       "alg": "com.writerslogic.zwc-watermark.1",
+        "identifier": 29,
+        "alg": "com.writerslogic.zwc-watermark.1",
         "type": "watermark",
         "encodedMediaTypes": [
             "text/plain",
@@ -619,5 +619,22 @@
             "contact": "support@cognitive-proof.com",
             "informationalUrl": "https://github.com/Cognitive-Proof/VSRMark"
         }
+    },
+    {
+        "identifier": 40,
+        "alg": "me.deepmark.audio.vigil.128",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "audio"
+        ],
+        "entryMetadata": {
+            "description": "Vigil is a 128-bit-per-second neural audio watermarking algorithm developed by DeepMark Inc. Real-time capable on both CPU and GPU. Embedding can be performed by the DeepMark ingestion API at https://ingestion-api.deepmark.me. NOTE: This deployment signs manifests with test certificates, so manifest signatures will not validate against any trust authority.",
+            "dateEntered": "2026-06-05T00:00:00Z",
+            "contact": "hello@deepmark.me",
+            "informationalUrl": "https://www.deepmark.me"
+        },
+        "softBindingResolutionApis": [
+            "https://resolution-api.deepmark.me"
+        ]
     }
 ]


### PR DESCRIPTION
Resolves #53 — adds the DeepMark Vigil audio watermarking entry (identifier 40) to the list.

This is a rebase of #53 onto current `main`, resolving the conflict with the Cognitive Proof entry (identifier 39) that was merged in the meantime. As this PR was created with a fork I could not push to the fork. 
