### PR TITLE
Add com.writerslogic.text-watermark-semantic.1 (id 46)

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -721,7 +721,7 @@
         ]
     },
     {
-        "identifier": 46,
+        "identifier": 47,
         "alg": "com.writerslogic.text-watermark-semantic.1",
         "type": "watermark",
         "encodedMediaTypes": [

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -719,5 +719,21 @@
         "softBindingResolutionApis": [
             "https://api.blockfact.io/api/soft-binding/v1"
         ]
+    },
+    {
+        "identifier": 46,
+        "alg": "com.writerslogic.text-watermark-semantic.1",
+        "type": "watermark",
+        "encodedMediaTypes": [
+            "text/plain",
+            "text/markdown",
+            "text/html"
+        ],
+        "entryMetadata": {
+            "description": "WritersLogic CPoE post-hoc semantic embedding watermark for paraphrase- and translation-robust manuscript identification. Applies key-conditioned dual-embedding watermarking: the text is revised post-generation via semantic-preserving lexical substitutions selected to align the document's contextual sentence-level and token-level embedding representations with a secret-key-derived watermark direction in the shared embedding space. Detection requires only the secret key and the candidate text; a one-sided hypothesis test on the dot product of the extracted dual embedding against the watermark direction determines presence or absence at a calibrated false-positive rate. The secret key is never embedded in the text and is not disclosed during verification. Robust to paraphrase, translation, format conversion, re-encoding, and zero-width-character injection, because the signal is anchored in the semantic embedding space rather than in surface characters or token statistics. Not robust to complete rewriting that substantially changes meaning. Works on any existing text without generation-time access; applicable to both AI-generated and human-authored content. Part of the CPoE proof-of-effort authorship attestation system implementing draft-condrey-cpoe-protocol.",
+            "dateEntered": "2026-07-28T00:00:00.000Z",
+            "contact": "david@writerslogic.com",
+            "informationalUrl": "https://docs.writerslogic.com/soft-binding/text-watermark-semantic"
+        }
     }
 ]


### PR DESCRIPTION
Adds com.writerslogic.text-watermark-semantic.1 (identifier 46), a watermark-type soft binding for text content.

The algorithm is a post-hoc semantic embedding watermark. Semantic-preserving lexical substitutions are selected to align the document's contextual sentence-level and token-level embeddings with a secret-key-derived watermark direction in the shared embedding space. Detection requires only the secret key and the candidate text; a one-sided hypothesis test on the dot product of the extracted dual embedding against the watermark direction determines presence or absence at a calibrated false-positive rate. No generation-time access is required, so the algorithm applies to both AI-generated and human-authored content. The secret key is never embedded in the text and is not disclosed during verification.

Unlike com.writerslogic.zwc-watermark.1 and .2 (ids 29, 42), which anchor the signal in zero-width characters and fail when those characters are stripped, this entry anchors the signal in the semantic embedding space. It is robust to paraphrase, translation, format conversion, re-encoding, and zero-width-character injection; not robust to complete rewriting that substantially changes meaning.