### PR TITLE
Add com.joinmonolith.sha256 (Monolith SHA-256 content fingerprint)

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -733,6 +733,26 @@
             "contact": "c2pa@Doverunner.com",
             "informationalUrl": "https://docs.doverunner.com/content-security/"
         }
-
-    }    
+    },
+    {
+        "identifier": 48,
+        "alg": "com.joinmonolith.sha256",
+        "type": "fingerprint",
+        "decodedMediaTypes": [
+            "image",
+            "video",
+            "audio",
+            "text",
+            "application"
+        ],
+        "entryMetadata": {
+            "description": "Monolith SHA-256 content fingerprint for C2PA manifest recovery",
+            "dateEntered": "2026-07-29T00:00:00.000Z",
+            "contact": "contact@joinmonolith.com",
+            "informationalUrl": "https://docs.joinmonolith.com/guide/fingerprinting"
+        },
+        "softBindingResolutionApis": [
+            "https://api.joinmonolith.com/api/c2pa"
+        ]
+    }
 ]


### PR DESCRIPTION
Adds one entry registering the Monolith SHA-256 content fingerprint as `com.joinmonolith.sha256` (type `fingerprint`).

### Resolution

`softBindingResolutionApis` points at `https://api.joinmonolith.com/api/c2pa`, a Soft Binding Resolution API that is **publicly readable on its spec paths, no credentials required**:

```
GET /api/c2pa/services/supportedAlgorithms
  -> 200 {"fingerprints":[{"alg":"com.joinmonolith.sha256"}]}

GET /api/c2pa/matches/byBinding?alg=com.joinmonolith.sha256&value=<base64>
  -> 200 {"matches":[...]}

GET /api/c2pa/manifests/{manifestId}
  -> 200, or 404 for an unknown id
```

Manifests are independently resolvable without credentials through the GeneralizedClaimRegistry contract on the Stability Protocol network (`0xfE9daFC133eD3e9726D4B2c24b8cC3c3AaDD8225`, chain 101010) via the C2PA Federated Lookup smart-contract interface. That path is documented at the `informationalUrl`.

### Checklist against the README criteria

- [x] Conforms with the schema, all mandatory fields present — validated locally against `softbinding-algorithm-list.schema.json`
- [x] Not malicious or spam
- [x] Submitted by an individual affiliated with the company owning the algorithm
- [x] URLs resolve — `informationalUrl` and the SBR API spec paths all return 200 (see the note above about the bare base path)
- [x] Supports extracting a soft binding identifier for the purpose of manifest recovery
- [x] New entry, so the `identifier` / `alg` / `type` immutability rule does not apply
