### PR TITLE
Add me.reconize.videoseal.1 to softbinding algorithm list

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -770,5 +770,20 @@
         "softBindingResolutionApis": [
             "https://api.joinmonolith.com/api/c2pa"
         ]
+    },
+    {
+        "identifier": 49,
+        "alg": "me.reconize.videoseal.1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "image",
+            "video"
+        ],
+        "entryMetadata": {
+            "description": "Reconize deployment of the VideoSeal invisible watermark (Meta AI open research), embedding a 256-bit identity payload into image and video pixels via on-device Core ML. Used by the Reconize Mac app (C2PA conformant Generator Product) to bind C2PA manifests to pixels so provenance survives metadata stripping.",
+            "dateEntered": "2026-08-10T00:00:00.000Z",
+            "contact": "hello@reconize.me",
+            "informationalUrl": "https://reconize.me/softbinding.html"
+        }
     }
 ]

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -772,7 +772,7 @@
         ]
     },
     {
-        "identifier": 49,
+        "identifier": 50,
         "alg": "me.reconize.videoseal.1",
         "type": "watermark",
         "decodedMediaTypes": [


### PR DESCRIPTION
Adds the me.reconize.videoseal.1 entry for Reconize's deployment of VideoSeal invisible watermarking (Meta AI open research, MIT licensed, converted to on-device Core ML). Reconize is a C2PA-conformant Generator Product (Max Assurance Level 1) on the conforming products list, shipping on the Mac App Store; I'm its developer (Lil Dog Productions, LLC). The algorithm embeds a 256-bit payload in image/video pixels and is asserted via c2pa.soft-binding in the soft-binding-map shape. Algorithm details: https://reconize.me/softbinding.html