### PR TITLE
Add Sigi invisible watermarking engine (io.diker.sigi.v1)

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -772,7 +772,7 @@
         ]
     },
     {
-        "identifier": 49,
+        "identifier": 51,
         "alg": "io.diker.sigi.v1",
         "type": "watermark",
         "decodedMediaTypes": [

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -770,5 +770,19 @@
         "softBindingResolutionApis": [
             "https://api.joinmonolith.com/api/c2pa"
         ]
+    },
+    {
+        "identifier": 49,
+        "alg": "io.diker.sigi.v1",
+        "type": "watermark",
+        "decodedMediaTypes": [
+            "image"
+        ],
+        "entryMetadata": {
+            "description": "Sigi invisible watermarking engine by Okeanos B.V.",
+            "dateEntered": "2026-08-11T00:00:00.000Z",
+            "contact": "support@diker.io",
+            "informationalUrl": "https://diker.io/sigi"
+        }
     }
 ]


### PR DESCRIPTION
Adds the Sigi invisible watermarking engine to the soft binding algorithm list.

**Algorithm details:**

| Field | Value |
|-------|-------|
| `alg` | `io.diker.sigi.v1` |
| `type` | `watermark` |
| `decodedMediaTypes` | `image` |
| `contact` | support@diker.io |
| `informationalUrl` | https://diker.io/sigi |

**About Sigi:**

Sigi is an invisible forensic watermarking engine developed by Okeanos B.V. It embeds an imperceptible signal in pixel data that survives compression, screenshots, cropping, social media re-encoding, and format conversion.

**About Okeanos B.V.:**

Okeanos B.V. is a C2PA Conforming Implementer with two conformant Generator Products:
- **Artimis** (approved 2026-05-05)
- **Diker** (approved 2026-08-10, Assurance Level 1)

Sigi ships as the watermarking layer inside Diker's provenance pipeline and is declared in C2PA manifests via the `c2pa.soft-binding` assertion.

I am the director of Okeanos B.V. 