### PR TITLE
Declare Trufo's Soft Binding Resolution API endpoint

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -122,7 +122,10 @@
             "dateEntered": "2024-08-14T15:00:00.000Z",
             "contact": "support@trufo.ai",
             "informationalUrl": "https://trufo.ai/watermarks"
-        }
+        },
+        "softBindingResolutionApis": [
+            "https://c2pa.trufo.ai"
+        ]
     },
     {
         "identifier": 9,
@@ -138,7 +141,10 @@
             "dateEntered": "2024-08-14T15:00:00.000Z",
             "contact": "support@trufo.ai",
             "informationalUrl": "https://trufo.ai/watermarks"
-        }
+        },
+        "softBindingResolutionApis": [
+            "https://c2pa.trufo.ai"
+        ]
     },
     {
         "identifier": 10,

--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -124,7 +124,7 @@
             "informationalUrl": "https://trufo.ai/watermarks"
         },
         "softBindingResolutionApis": [
-            "https://c2pa.trufo.ai"
+            "https://c2pa.trufo.ai/v1"
         ]
     },
     {
@@ -143,7 +143,7 @@
             "informationalUrl": "https://trufo.ai/watermarks"
         },
         "softBindingResolutionApis": [
-            "https://c2pa.trufo.ai"
+            "https://c2pa.trufo.ai/v1"
         ]
     },
     {


### PR DESCRIPTION
Adds `softBindingResolutionApis` to Trufo's two existing entries (identifiers 8 and 9, `ai.trufo.pawprint.watermark` and `ai.trufo.pawprint.fingerprint`), declaring our resolution endpoint at https://c2pa.trufo.ai/v1, which implements the standard Soft Binding Resolution API for C2PA Manifest Recovery.

Validated against `softbinding-algorithm-list.schema.json`.