### PR TITLE
Add image/webp to eu.sasha.softbinding.v1 encoded media types

### DIFF
--- a/softbinding-algorithm-list.json
+++ b/softbinding-algorithm-list.json
@@ -514,7 +514,8 @@
         ],
         "encodedMediaTypes": [
             "image/jpeg",
-            "image/png"
+            "image/png",
+            "image/webp"
         ],
         "entryMetadata": {
             "description": "Invisible watermarking technology for image and video assets, enabling C2PA manifest recovery and content provenance verification after metadata stripping or transcoding.",


### PR DESCRIPTION
Updates the existing Sasha entry (identifier 33, `eu.sasha.softbinding.v1`) to add `image/webp` to its `encodedMediaTypes`.

Sasha's invisible watermarking engine embeds and extracts the soft-binding identifier in WebP in addition to the already-listed JPEG and PNG. This brings the entry in line with the formats the algorithm actually supports.

Algorithm: eu.sasha.softbinding.v1
Type: watermark (unchanged)
Identifier: 33 (unchanged)
Change: encodedMediaTypes += image/webp
Contact: contact@sasha.eu
Info: https://sasha.eu/technology

I'm affiliated with SASHA ApS, which owns this proprietary algorithm. Immutable fields (identifier, alg, type) are unchanged.